### PR TITLE
Upgrade Phaser Version && Fix Gestures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -9077,9 +9077,9 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "phaser": {
-      "version": "3.18.1",
-      "resolved": "https://registry.npmjs.org/phaser/-/phaser-3.18.1.tgz",
-      "integrity": "sha512-vA6mqrSm5gy/dGwzmcwglKd8q3Y96dvecOlpBcfhdyrCRWM/jfyBVkAuVLhkAj7Mii7yTgW2K7tnVndItXnF6Q==",
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/phaser/-/phaser-3.19.0.tgz",
+      "integrity": "sha512-dEohGFXik3bDCpNqk/b8yxpyMbP99jaP2Aoa1V4UcagLpHOYsNDYt4R+swJv9bCl6qaxvPGPstx7qJALtgDJOg==",
       "requires": {
         "dts-dom": "^3.2.0",
         "eventemitter3": "^3.1.0",
@@ -9087,6 +9087,7 @@
         "imports-loader": "^0.8.0",
         "jsdoc": "^3.6.1",
         "path": "^0.12.7",
+        "remove-files-webpack-plugin": "^1.1.3",
         "typescript": "^3.4.5"
       }
     },
@@ -10640,6 +10641,11 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
+    },
+    "remove-files-webpack-plugin": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/remove-files-webpack-plugin/-/remove-files-webpack-plugin-1.1.3.tgz",
+      "integrity": "sha512-r53wQ/IlTkmcv11wri71CZ27S+GhFI5SjHbTbaAJbisPC3qGwg87vlA2C5Z1PuVA+aMI8SgimnE4SqI+ZYzu6Q=="
     },
     "remove-trailing-separator": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "https://wjxhenry.github.io/Phaser-Maze-Game/",
   "dependencies": {
-    "phaser": "^3.18.1",
+    "phaser": "^3.19.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-scripts": "3.0.1"

--- a/src/Phaser/Utils/gestures.js
+++ b/src/Phaser/Utils/gestures.js
@@ -22,16 +22,13 @@ export const GESTURES = {
  */
 export function gestureDetection(inputManager, callback, options = {}) {
   inputManager.on('pointerup', pointer => {
-    // TODO: change the detectGesture function to base it on speed of swipe (once Phaser has its new release)
-    callback(detectGestureNoTime(pointer, options));
+    callback(detectGesture(pointer, options));
   });
 }
 
-/**
- * Commenting out to prevent eslint from throwing 'no-unused-vars'
 function detectGesture(pointer, options) {
   let swipeThreshold = options.swipeThreshold || 100;
-  let deltaTime = pointer.getDuration();
+  let deltaTime = (pointer.upTime - pointer.downTime) / 1000;
   let velX = (pointer.upX - pointer.downX) / deltaTime;
   let velY = (pointer.upY - pointer.downY) / deltaTime;
   let speedX = Math.abs(velX);
@@ -51,9 +48,9 @@ function detectGesture(pointer, options) {
   }
   return GESTURES.SINGLE_TAP;
 }
- */
 
 // Swipe gestures without using time (speed/velocity)
+// eslint-disable-next-line
 function detectGestureNoTime(pointer, options) {
   let swipeThreshold = options.swipeThreshold || 50;
   let displacementX = pointer.upX - pointer.downX;


### PR DESCRIPTION
Closes #9 

- Uses the newest version of Phaser that fixes the `Pointer.upTime` and `Pointer.downTime` issue.
- Reverts to detecting gestures using speed/velocity