### PR TITLE
Move graphics settings to 'gameMaze' class

### DIFF
--- a/src/Phaser/Game/gameMaze.js
+++ b/src/Phaser/Game/gameMaze.js
@@ -15,6 +15,7 @@ export default class GameMaze extends Maze {
     this.size = size;
     this.game = game;
     this.graphics = graphics;
+    this.graphics.setPosition(1, 1); // The border for the maze is 1
     this.gameDimensions = getDimensions(this.game);
     this.sideLength = (this.gameDimensions.screenLength - 2) / size;
     this.colour = colour;

--- a/src/Phaser/Scenes/StartGame.js
+++ b/src/Phaser/Scenes/StartGame.js
@@ -45,11 +45,7 @@ export default class StartGame extends Phaser.Scene {
     // TODO: method to initialise different game modes -> or implement the different game modes as different scenes!
     // TODO: side length is not needed -> just calculate from grid size and window length
 
-    // The border for the maze is 1
-    this.graphics = this.add.graphics({
-      x: 1,
-      y: 1
-    });
+    this.graphics = this.add.graphics();
 
     this.maze = new GameMaze(this.game, this.graphics, this.settings.gridSize);
 


### PR DESCRIPTION
Setting the position of the `graphics` game object in the `gameMaze` class seems to make more sense than setting it in each scene.