### PR TITLE
Increase number of active pointers for detecting gestures

### DIFF
--- a/src/Phaser/Game.js
+++ b/src/Phaser/Game.js
@@ -24,6 +24,9 @@ export default class Game extends React.Component {
           gravity: { y: 200 }
         }
       },
+      input: {
+        activePointers: 5 // Set the number of allowed active pointers
+      },
       scene: [
         MainMenu,
         Settings,

--- a/src/Phaser/Game/gestures.js
+++ b/src/Phaser/Game/gestures.js
@@ -27,15 +27,15 @@ export const GESTURES = {
 };
 
 /**
- * Register input manager for gesture detection
- * @param {Phaser.Input.InputPlugin} inputManager - The input manager that handles all input related events
+ * Register input plugin for gesture detection
+ * @param {Phaser.Input.InputPlugin} inputPlugin - The input plugin that handles all input related events
  * @callback callback - The callback function that handles the detected gesture
  *  @param {Detection} detection - The detected gesture
  * @param {Object} [options]
  * @param {Number} [options.swipeThreshold] - The swipe threshold for the detection
  */
-export function gestureDetection(inputManager, callback, options = {}) {
-  inputManager.on('pointerup', pointer => {
+export function gestureDetection(inputPlugin, callback, options = {}) {
+  inputPlugin.on('pointerup', pointer => {
     callback(detectGesture(pointer, options));
   });
 }

--- a/src/Phaser/Scenes/GamemodeTwoPlayer.js
+++ b/src/Phaser/Scenes/GamemodeTwoPlayer.js
@@ -35,7 +35,6 @@ export default class GamemodeTwoPlayer extends Phaser.Scene {
       p2Right: 'D',
       exit: 'Esc'
     });
-    this.input.addPointer(3); // Increase the number of active pointers allowed
     gestureDetection(this.input, this.handleGesture);
 
     this.graphics = this.add.graphics();

--- a/src/Phaser/Scenes/GamemodeTwoPlayer.js
+++ b/src/Phaser/Scenes/GamemodeTwoPlayer.js
@@ -35,6 +35,7 @@ export default class GamemodeTwoPlayer extends Phaser.Scene {
       p2Right: 'D',
       exit: 'Esc'
     });
+    this.input.addPointer(3); // Increase the number of active pointers allowed
     gestureDetection(this.input, this.handleGesture);
 
     this.graphics = this.add.graphics();


### PR DESCRIPTION
Closes #33 

Enabling more active pointers allows for gestures from both players in two player mode to be detected. The number of active pointers enabled was set to an arbitrary number (chosen to be *5*). The maximum number of active pointers is *10* - noted [here](https://photonstorm.github.io/phaser3-docs/Phaser.Input.Pointer.html).

Also renamed `inputManager` to (more accurately) `inputPlugin` in the `gestureDetection` function.